### PR TITLE
Fix deprecated default parameter signature

### DIFF
--- a/web/models/alternate_feed.ex
+++ b/web/models/alternate_feed.ex
@@ -18,7 +18,7 @@ defmodule Pan.AlternateFeed do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/category.ex
+++ b/web/models/category.ex
@@ -22,7 +22,7 @@ defmodule Pan.Category do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/chapter.ex
+++ b/web/models/chapter.ex
@@ -18,7 +18,7 @@ defmodule Pan.Chapter do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/contributor.ex
+++ b/web/models/contributor.ex
@@ -20,7 +20,7 @@ defmodule Pan.Contributor do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/enclosure.ex
+++ b/web/models/enclosure.ex
@@ -20,7 +20,7 @@ defmodule Pan.Enclosure do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/episode.ex
+++ b/web/models/episode.ex
@@ -35,7 +35,7 @@ defmodule Pan.Episode do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:guid)

--- a/web/models/feed.ex
+++ b/web/models/feed.ex
@@ -25,7 +25,7 @@ defmodule Pan.Feed do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end

--- a/web/models/language.ex
+++ b/web/models/language.ex
@@ -18,7 +18,7 @@ defmodule Pan.Language do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:shortcode)

--- a/web/models/podcast.ex
+++ b/web/models/podcast.ex
@@ -39,7 +39,7 @@ defmodule Pan.Podcast do
   If no params are provided, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:title)

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -26,7 +26,7 @@ defmodule Pan.User do
                  join_through: "followers_users", join_keys: [follower_id: :id, user_id: :id]
   end
 
-  def changeset(model, params \\ :empty) do
+  def changeset(model, params \\ %{}) do
     model
     |> cast(params, @required_fields, @optional_fields)
     |> validate_length(:username, min: 3, max: 30)


### PR DESCRIPTION
This eliminates a deprecation warning when for example loading `/users/new`